### PR TITLE
ナビゲーションメニューに開催概要などへのリンクを追加

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -23,8 +23,8 @@
     {% endfor %}
   </ul>
 
-  <!-- Inpage link -->
   {% if page.linksection %}
+  <!-- Inpage link -->
   <ul class="menu">
     {% for link in page.linksection %}
     {% capture sectionurl %}/#{{ link.id }}{% endcapture %}

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -21,29 +21,19 @@
         </li>
       {% endif %}
     {% endfor %}
-
-    <li class="menu-item">
-      <a href="{{ '/#開催概要' | relative_url }}" itemprop="url">
-        <span itemprop="name">開催概要</span>
-      </a>
-    </li>
-
-    <li class="menu-item">
-      <a href="{{ '/#sponsor' | relative_url }}" itemprop="url">
-        <span itemprop="name">スポンサー</span>
-      </a>
-    </li>
-
-    <li class="menu-item">
-      <a href="{{ '/#タイムテーブル' | relative_url }}" itemprop="url">
-        <span itemprop="name">タイムテーブル</span>
-      </a>
-    </li>
-
-    <li class="menu-item">
-      <a href="{{ '/#実行委員長より' | relative_url }}" itemprop="url">
-        <span itemprop="name">実行委員長より</span>
-      </a>
-    </li>
   </ul>
+
+  <!-- Inpage link -->
+  {% if page.linksection %}
+  <ul class="menu">
+    {% for link in page.linksection %}
+    {% capture sectionurl %}/#{{ link.id }}{% endcapture %}
+      <li class="menu-item">
+        <a href="{{ sectionurl | relative_url }}" itemprop="url">
+          <span itemprop="name">{{ link.caption }}</span>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
 </nav>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,0 +1,49 @@
+<nav id="primary-nav" class="site-nav" itemscope itemtype="http://schema.org/SiteNavigationElement" aria-label="Main navigation">
+  <ul id="menu-main-navigation" class="menu">
+    <!-- Home link -->
+    <li class="menu-item">
+      <a href="{{ '/' | relative_url }}" itemprop="url">
+        <span itemprop="name">{{ site.data.theme.t.home | default: 'Home' }}</span>
+      </a>
+    </li>
+
+    <!-- site.pages links -->
+    {% assign default_paths = site.pages | map: "path" %}
+    {% assign page_paths = site.data.theme.navigation_pages | default: default_paths %}
+
+    {% for path in page_paths %}
+      {% assign my_page = site.pages | where: "path", path | first %}
+      {% if my_page.title %}
+        <li class="menu-item">
+          <a href="{{ my_page.url | relative_url }}" itemprop="url">
+            <span itemprop="name">{{ my_page.title | escape }}</span>
+          </a>
+        </li>
+      {% endif %}
+    {% endfor %}
+
+    <li class="menu-item">
+      <a href="{{ '/#開催概要' | relative_url }}" itemprop="url">
+        <span itemprop="name">開催概要</span>
+      </a>
+    </li>
+
+    <li class="menu-item">
+      <a href="{{ '/#sponsor' | relative_url }}" itemprop="url">
+        <span itemprop="name">スポンサー</span>
+      </a>
+    </li>
+
+    <li class="menu-item">
+      <a href="{{ '/#タイムテーブル' | relative_url }}" itemprop="url">
+        <span itemprop="name">タイムテーブル</span>
+      </a>
+    </li>
+
+    <li class="menu-item">
+      <a href="{{ '/#実行委員長より' | relative_url }}" itemprop="url">
+        <span itemprop="name">実行委員長より</span>
+      </a>
+    </li>
+  </ul>
+</nav>

--- a/index.md
+++ b/index.md
@@ -4,6 +4,15 @@
 
 layout: home
 image: /assets/images/SOTM_2017.jpg
+linksection:
+  - caption: "開催概要"
+    id: "開催概要"
+  - caption: "スポンサー"
+    id: "sponsor"
+  - caption: "タイムテーブル"
+    id: "タイムテーブル"
+  - caption: "実行委員長より"
+    id: "実行委員長より"
 ---
 
 ## [講演提案を6/18まで受付中](presentations.html)


### PR DESCRIPTION
右上のハンバーガーメニューから開催概要､スポンサー､タイムテーブル､実行委員長よりへの各リンクを追加しました｡ https://github.com/osmfj/sotmjp2018/issues/13

こんな感じいいでしょうか?

![default](https://user-images.githubusercontent.com/6219187/39965750-2085bb42-56da-11e8-97b1-c9b983fc1335.PNG)
