### PR TITLE
Stroly様スポンサー講演追加の編集

### DIFF
--- a/_includes/timetable.html
+++ b/_includes/timetable.html
@@ -11,10 +11,18 @@
    <tbody>
       <tr>
          <th>10:00</th>
-         <td class="joined" colspan="3">開場</td>
+         <td class="joined" colspan="3">受付開始(開場)</td>
       </tr>
       <tr>
-         <th>10:30-11:15</th>
+        <th>10:20-10:30</th>
+        <td class="splited">
+          開会あいさつ、スケジュール説明
+        </td>
+        <td class="splited scope-out"></td>
+        <td class="splited scope-out"></td>
+      </tr>
+      <tr>
+         <th>10:30-11:10</th>
          <td class="splited">
             <div class="slot-cell">
                <div class="slot-room">メインホール</div>
@@ -31,11 +39,11 @@
          <td class="splited scope-out"></td>
       </tr>
       <tr>
-         <th>11:15-11:30</th>
+         <th>11:10-11:25</th>
          <td class="joined" colspan="3">Short break</td>
       </tr>
       <tr>
-         <th>11:30-12:10</th>
+         <th>11:25-12:05</th>
          <td class="splited">
             <div class="slot-cell">
                <div class="slot-room">メインホール</div>
@@ -52,7 +60,7 @@
          <td class="splited scope-out"></td>
       </tr>
       <tr>
-         <th>12:10-12:30</th>
+         <th>12:05-12:25</th>
          <td class="splited">
             <div class="slot-cell">
                <div class="slot-room">メインホール</div>
@@ -69,11 +77,27 @@
          <td class="splited scope-out"></td>
       </tr>
       <tr>
-         <th>12:30-13:30</th>
+         <th>12:25-12:45</th>
+         <td class="splited">
+            <div class="slot-cell">
+               <div class="slot-room">メインホール</div>
+               <div class="session">
+                 <p class="session-title">スポンサー講演</p>
+                 <p class="session-speaker">
+                   株式会社Stroly
+                 </p>
+               </div>
+            </div>
+         </td>
+         <td class="splited scope-out"></td>
+         <td class="splited scope-out"></td>
+      </tr>
+      <tr>
+         <th>12:45-13:45</th>
          <td class="joined" colspan="3">Lunch</td>
       </tr>
       <tr>
-         <th>13:30-14:30</th>
+         <th>13:45-14:45</th>
          <td class="splited">
             <div class="slot-cell">
                <div class="slot-room">メインホール</div>
@@ -127,8 +151,8 @@
          </td>
       </tr>
       <tr>
-         <th>14:30-15:00</th>
-         <td class="joined" colspan="3">Break</td>
+         <th>14:45-15:00</th>
+         <td class="joined" colspan="3">Short Break</td>
       </tr>
       <tr>
          <th>15:00-16:00</th>


### PR DESCRIPTION
14:30-15:00の30分休憩を15分にして岡本さんの基調講演を講演依頼記載の通り40分間へ｡
開会あいさつ、スケジュール説明を追加｡
Stroly様スポンサー講演の追加｡

https://github.com/osmfj/sotmjp2018/issues/34