### PR TITLE
セッション概要のページを作成

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -27,7 +27,7 @@
   <!-- Inpage link -->
   <ul class="menu">
     {% for link in page.linksection %}
-    {% capture sectionurl %}/#{{ link.id }}{% endcapture %}
+    {% capture sectionurl %}{{ page.url }}#{{ link.id }}{% endcapture %}
       <li class="menu-item">
         <a href="{{ sectionurl | relative_url }}" itemprop="url">
           <span itemprop="name">{{ link.caption }}</span>

--- a/assets/stylesheets/talk.css
+++ b/assets/stylesheets/talk.css
@@ -1,0 +1,34 @@
+---
+---
+
+.talk-speaker {
+  display: inline-block;
+  font-size: 3em;
+  border-bottom: 3px solid #ddddff;
+}
+
+.talk-title {
+  display: block;
+  font-size: 1.8em;
+}
+
+.hallname {
+  font-size: 3.5em;
+  margin-bottom: .25rem;
+}
+
+.hallname > span {
+  border-bottom: 3px solid #ddddff;
+}
+
+.talk-session {
+  margin-left: 1em;
+}
+
+.time-range::before {
+  content: '- '
+}
+
+.time-range::after {
+  content: ' -'
+}

--- a/talk.html
+++ b/talk.html
@@ -1,0 +1,126 @@
+---
+layout: page
+title: セッション概要
+linksection:
+  - caption: "メインホール"
+    id: "メインホール"
+  - caption: "スタジオプラス"
+    id: "スタジオプラス"
+  - caption: "セミナーA"
+    id: "セミナーA"
+---
+<link rel="stylesheet" href="{{ '/assets/stylesheets/talk.css' | relative_url }}">
+
+<h2 class="hallname" id="メインホール"><span>メインホール</span></h2>
+
+<h3 class="time-range">13:45-14:45</h3>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="A-10">SATOSHI IIDA</span>
+  <span class="talk-title">OSMFJのおしごと</span>
+  <p class="talk-description">日本地域におけるOSMFJの役割、本家との関係性についてセッションです。</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="A-20">和田 清人</span>
+  <span class="talk-title">お城の魅力をOSMで表現しよう。</span>
+  <p class="talk-description">日本１００名城を中心に、お城をマッピングしています。<br>軍事上の防衛施設であるお城が持つ石垣・堀・城門などの役割を少し解説させていただいた後、実際に描いた実績をいくつかご紹介します。<br>お城に残された構造物を「地物として記録する」ことで、後にOSMを眺めた時に、計算し尽くされた防御上のノウハウに思いを馳せることができます。<br>天守閣に登ることだけがお城の楽しみ方ではないことをお伝えします。</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="A-30">淡路ザイラ</span>
+  <span class="talk-title">国際カンファレンスSOTMへのボランティア参加</span>
+  <p class="talk-description">去年の夏、私は会津で開催されたSotM会議のボランティアスタッフの一人でした。<br>私の経験の中で、私は様々な国から出会った人々に驚きました。<br>私は多く人々から多くの話を聞くことができました。<br>彼らが世界中の人々のためにどのように地図を作ったかを見ることは面白かったです。<br>私は彼らのプレゼンテーションを聴いてスピーカーがいかに熱心であるかを感じました。<br>また、様々な文化や習慣を持つ様々な国から集まった人々がカンファレンスで一箇所に集まっていることは非常に印象的でした。<br>SotMイベントは、人々を社会に導く重要な役割を果たすための地図作成が実現していることを知りました。<br>私はSotMコミュニティが世界を変えることができると信じています。<br>SotMにボランティア参加した体験と感想、私のとってのSotMについてお話ししたいです。</p>
+</div>
+
+<h3 class="time-range">15:00-16:00</h3>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="A-40">山下 康成</span>
+  <span class="talk-title">マッピングパーティを開催しよう！</span>
+  <p class="talk-description">3年以上にわたって、ほぼ毎月マッピングパーティを開催してきた実績と、その経験からマッピングパーティを開催する秘訣を共有させていただきます。</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="A-50">木村 浩之</span>
+  <span class="talk-title">OSMの世界で起きていることをあなたにお届け、WeeklyOSM</span>
+  <p class="talk-description">毎週世界中のOSM関連ニュースを複数言語でお知らせしているWeeklyOSMと、そこで動いているシステムや作業サイクル、あなたもできる参加方法をご紹介します。</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="A-60">Kinya Inoue</span>
+  <span class="talk-title">国際カンファレンスSotM2017の開催舞台裏</span>
+  <p class="talk-description">開催者目線から国際カンファレンスSotM2017の開催について報告します。開催決定、準備、OSM財団との連携など。</p>
+</div>
+
+<h2 class="hallname" id="スタジオプラス"><span>スタジオプラス</span></h2>
+
+<h3 class="time-range">14:05-14:45</h3>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="B-20">渡邉 剛広</span>
+  <span class="talk-title">360°写真のすすめ</span>
+  <p class="talk-description">Mapillaryを使用した、360°サービスを利用したOSMでの編集について</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="B-30">瀧口 典子</span>
+  <span class="talk-title">Mapframe 使ってみよう！</span>
+  <p class="talk-description">OpenStreetMapのデータを用いたWikipediaでの地図活用「Mapframe」<br>uMapのように、地点アイコンをクリックして開くポップアップウィンドウに、写真も表示できて凄い！この感動をお伝えします。</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="B-35">三浦＆井上</span>
+  <span class="talk-title">SotMイタリア報告</span>
+  <p class="talk-description">11回目のOpenStreetMap年次国際会議としてState of the Map 2018が7月28日～30日の3日間、イタリア、ミラノで開催されます。昨年はState of the Map 2017として日本、会津若松市で開催され国内外から多くの参加がありました。OpenStreetMapが盛んな欧州、イタリアでの初開催となったSotM2018ミラノへ参加した最新レポートと感想を発表します。</p>
+</div>
+
+<h3 class="time-range">15:00-16:00</h3>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="B-40">目黒 純</span>
+  <span class="talk-title">Mapillaryによる歩道状況調査とマッピング</span>
+  <p class="talk-description">Mapillaryと全天球カメラによる歩道状況の調査とOSMへの反映</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="B-50">澤田 学</span>
+  <span class="talk-title">車載動画マッピングをやってみよう!</span>
+  <p class="talk-description">私はレンタカーでドライブするのが趣味です。その際に必ずといってもいいほど車載動画を撮影し、後で一つの動画として編集し、旅の記録として残し、見返しては楽しんでいます。現在、車載動画27個、容量322GBあります。<br>さて、車載動画は旅の記録だけではありません。マッピングするためツールとしての役割があると思います。車載動画では様々な景色が広がります。マッピングできますよね?私は、これを「車載動画マッピング」と名付けました。車載動画マッピングは2つのマッピング方法があります。1つは車載動画とOSM地図を見ながらマッピングしていく方法、2つは動画を静止画化として切り取って、静止画像を「Mapillary」にアップロードするマッピングする方法。<br>さあ、みんなで車載動画マッピングをやってみよう!!!</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="B-60">坂ノ下 勝幸</span>
+  <span class="talk-title">西日本も元気にやってますよ！</span>
+  <p class="talk-description">西日本のOpenStreetMap関連活動についてのご報告</p>
+</div>
+
+<h2 class="hallname" id="セミナーA"><span>セミナーA</span></h2>
+
+<h3 class="time-range">14:25-14:45</h3>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="C-30">瀬戸 寿一</span>
+  <span class="talk-title">OSMの利用の実態とデータ品質に関する認識について(仮)</span>
+  <p class="talk-description">Coming Soon!</p>
+</div>
+
+<h3 class="time-range">15:00-16:00</h3>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="C-40">林 優</span>
+  <span class="talk-title">POI別編集状況と対策</span>
+  <p class="talk-description">スタンプラリーのようにあらかじめマッピングするPOIの位置を計画して効率よく回ろうという提案です。まだマッピングされていないPOIを確認するサイトの紹介とその使い方。マッピングラリーのやり方の紹介など<br>バス停、警察署、交番、駐在所、ガソリンスタンドなどの都道府県別のカバー率１００％を目指しましょう。</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="C-50">三浦 広志</span>
+  <span class="talk-title">コミュニティ支援サービスの概観</span>
+  <p class="talk-description">コミュニティの活動を支援するサービスが沢山あり、全てを網羅して理解するのは、大変です。そこで、本セッションでは、できるだけ多くのサービスと使い方を紹介します。</p>
+</div>
+
+<div class="talk-session">
+  <span class="talk-speaker" id="C-60">松澤 太郎</span>
+  <span class="talk-title">OpenStreetMap.jp の新規タイルサーバ構築</span>
+  <p class="talk-description">OpenStreetMap.jp のタイルサーバが老朽化するのに伴い、新規のタイルサーバを構築し、新しい仕組みでの配信を開始する予定です(まだ作業中)。OpenMapTilesを使った新しい仕組みについて解説をします！</p>
+</div>


### PR DESCRIPTION
ナビゲーション内にあるページ内リンクのURLを修正
セッション概要のページを作成

セッション概要のページに飛ぶリンクはまだ付けていません。

OKそうなら _data/theme.yml を編集してセッション概要へのリンクを、_includes/timetable.html を編集して対応するセション説明の項目へのリンクをそれぞれ追加します。