### PR TITLE
セッション概要ページへのリンク追加

### DIFF
--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -35,4 +35,4 @@ google_fonts:
 
 navigation_pages:
   - about.md
-  - cv.md
+  - talk.html

--- a/_includes/timetable.html
+++ b/_includes/timetable.html
@@ -102,15 +102,15 @@
             <div class="slot-cell">
                <div class="slot-room">メインホール</div>
                <div class="session">
-                  <p class="session-title">OSMFJのおしごと</p>
+                  <p class="session-title"><a href="{{ 'talk.html#A-10' | relative_url }}">OSMFJのおしごと</a></p>
                   <p class="session-speaker">SATOSHI IIDA</p>
                </div>
                <div class="session">
-                  <p class="session-title">お城の魅力をOSMで表現しよう。</p>
+                  <p class="session-title"><a href="{{ 'talk.html#A-20' | relative_url }}">お城の魅力をOSMで表現しよう。</a></p>
                   <p class="session-speaker">和田 清人</p>
                </div>
                <div class="session">
-                  <p class="session-title">国際カンファレンスSOTMへのボランティア参加</p>
+                  <p class="session-title"><a href="{{ 'talk.html#A-30' | relative_url }}">国際カンファレンスSOTMへのボランティア参加</a></p>
                   <p class="session-speaker">淡路 ザイラ</p>
                </div>
             </div>
@@ -122,14 +122,14 @@
                  Stand-by
                </div>
                <div class="session">
-                  <p class="session-title">360°写真のすすめ</p>
+                  <p class="session-title"><a href="{{ 'talk.html#B-20' | relative_url }}">360°写真のすすめ</a></p>
                   <p class="session-speaker">渡邉 剛広</p>
                </div>
                <div class="session">
                  ライトニングトーク
-                  <p class="session-title">Mapframe 使ってみよう！</p>
+                  <p class="session-title"><a href="{{ 'talk.html#B-30' | relative_url }}">Mapframe 使ってみよう！</a></p>
                   <p class="session-speaker">瀧口 典子</p>
-                  <p class="session-title">SotMイタリア報告</p>
+                  <p class="session-title"><a href="{{ 'talk.html#B-35' | relative_url }}">SotMイタリア報告</a></p>
                   <p class="session-speaker">三浦&amp;井上</p>
                </div>
             </div>
@@ -144,7 +144,7 @@
                  Stand-by
                </div>
                <div class="session">
-                  <p class="session-title">日本におけるOSMの利用者/作成者側からみたデータ品質について</p>
+                  <p class="session-title"><a href="{{ 'talk.html#C-30' | relative_url }}">日本におけるOSMの利用者/作成者側からみたデータ品質について</a></p>
                   <p class="session-speaker">瀬戸 寿一</p>
                </div>
             </div>
@@ -160,15 +160,15 @@
             <div class="slot-cell">
                <div class="slot-room">メインホール</div>
                <div class="session">
-                  <p class="session-title">マッピングパーティを開催しよう！</p>
+                  <p class="session-title"><a href="{{ 'talk.html#A-40' | relative_url }}">マッピングパーティを開催しよう！</a></p>
                   <p class="session-speaker">山下 康成</p>
                </div>
                <div class="session">
-                  <p class="session-title">OSMの世界で起きていることをあなたにお届け、WeeklyOSM</p>
+                  <p class="session-title"><a href="{{ 'talk.html#A-50' | relative_url }}">OSMの世界で起きていることをあなたにお届け、WeeklyOSM</a></p>
                   <p class="session-speaker">木村 浩之</p>
                </div>
                <div class="session">
-                  <p class="session-title">国際カンファレンスSotM2017の開催舞台裏</p>
+                  <p class="session-title"><a href="{{ 'talk.html#A-60' | relative_url }}">国際カンファレンスSotM2017の開催舞台裏</a></p>
                   <p class="session-speaker">Kinya Inoue</p>
                </div>
             </div>
@@ -177,15 +177,15 @@
             <div class="slot-cell">
                <div class="slot-room">スタジオプラス</div>
                <div class="session">
-                  <p class="session-title">Mapillaryによる歩道状況調査とマッピング</p>
+                  <p class="session-title"><a href="{{ 'talk.html#B-40' | relative_url }}">Mapillaryによる歩道状況調査とマッピング</a></p>
                   <p class="session-speaker">目黒 純</p>
                </div>
                <div class="session">
-                  <p class="session-title">車載動画マッピングをやってみよう!</p>
+                  <p class="session-title"><a href="{{ 'talk.html#B-50' | relative_url }}">車載動画マッピングをやってみよう!</a></p>
                   <p class="session-speaker">澤田 学</p>
                </div>
                <div class="session">
-                  <p class="session-title">西日本も元気にやってますよ!</p>
+                  <p class="session-title"><a href="{{ 'talk.html#B-60' | relative_url }}">西日本も元気にやってますよ!</a></p>
                   <p class="session-speaker">坂ノ下 勝幸</p>
                </div>
             </div>
@@ -194,15 +194,15 @@
             <div class="slot-cell">
                <div class="slot-room">セミナーA</div>
                <div class="session">
-                  <p class="session-title">POI別編集状況と対策</p>
+                  <p class="session-title"><a href="{{ 'talk.html#C-40' | relative_url }}">POI別編集状況と対策</a></p>
                   <p class="session-speaker">林 優</p>
                </div>
                <div class="session">
-                  <p class="session-title">コミュニティ支援サービスの概観</p>
+                  <p class="session-title"><a href="{{ 'talk.html#C-50' | relative_url }}">コミュニティ支援サービスの概観</a></p>
                   <p class="session-speaker">三浦 広志</p>
                </div>
                <div class="session">
-                  <p class="session-title">OpenStreetMap.jp の新規タイルサーバ構築</p>
+                  <p class="session-title"><a href="{{ 'talk.html#C-60' | relative_url }}">OpenStreetMap.jp の新規タイルサーバ構築</a></p>
                   <p class="session-speaker">松澤 太郎</p>
                </div>
             </div>


### PR DESCRIPTION
ナビゲーションリンクとタイムテーブルからセッション概要ページへのリンクを追加

https://github.com/osmfj/sotmjp2018/issues/34